### PR TITLE
Change AnythingOfTypeArgument to AnythingOfType

### DIFF
--- a/server/service/notification_test.go
+++ b/server/service/notification_test.go
@@ -111,16 +111,16 @@ func TestGetNotificationsChannelIDs(t *testing.T) {
 			defer monkey.UnpatchAll()
 			mockAPI := baseMock()
 			mockAPI.On("LogError",
-				mock.AnythingOfTypeArgument("string"),
-				mock.AnythingOfTypeArgument("string"),
-				mock.AnythingOfTypeArgument("string"),
-				mock.AnythingOfTypeArgument("string"),
-				mock.AnythingOfTypeArgument("string"),
-				mock.AnythingOfTypeArgument("string"),
-				mock.AnythingOfTypeArgument("string"),
-				mock.AnythingOfTypeArgument("string"),
-				mock.AnythingOfTypeArgument("string"),
-				mock.AnythingOfTypeArgument("string")).Return(nil)
+				mock.AnythingOfType("string"),
+				mock.AnythingOfType("string"),
+				mock.AnythingOfType("string"),
+				mock.AnythingOfType("string"),
+				mock.AnythingOfType("string"),
+				mock.AnythingOfType("string"),
+				mock.AnythingOfType("string"),
+				mock.AnythingOfType("string"),
+				mock.AnythingOfType("string"),
+				mock.AnythingOfType("string")).Return(nil)
 			mockAPI.On("CreatePost", mock.AnythingOfType(model.Post{}.Type)).Return(&model.Post{}, nil)
 			monkey.Patch(GetSubscriptionsByURLSpaceKey, func(url, spaceKey string) (serializer.StringArrayMap, error) {
 				return val.urlSpaceKeyCombinationSubscriptions, nil


### PR DESCRIPTION
The `github.com/stretchr/testify` package has deprecated [`mock.AnythingOfTypeArgument`](https://pkg.go.dev/github.com/stretchr/testify/mock@v1.9.0#AnythingOfTypeArgument). All instances of `mock.AnythingOfTypeArgument` must just be replaced by `mock.AnythingOfType`.

Fixes https://github.com/mattermost-community/mattermost-plugin-confluence/issues/108